### PR TITLE
Add ipfs, ipfs_diff to BMSTable,DifficultyTable

### DIFF
--- a/src/bms/table/BMSTableElement.java
+++ b/src/bms/table/BMSTableElement.java
@@ -1,14 +1,17 @@
 package bms.table;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * 表の要素
- * 
+ *
  * @author exch
  */
 public abstract class BMSTableElement {
-	
+
 	private Map<String, Object> values = new HashMap<String, Object>();
 
 	/**
@@ -31,10 +34,10 @@ public abstract class BMSTableElement {
 	 * モード
 	 */
 	public static final String MODE = "mode";
-	
+
 	public BMSTableElement() {
 	}
-	
+
 	public String getTitle() {
 		return (String) values.get(TITLE);
 	}
@@ -42,13 +45,21 @@ public abstract class BMSTableElement {
 	public void setTitle(String title) {
 		values.put(TITLE, title);
 	}
-	
+
 	public String getURL() {
 		return (String)values.get("url");
 	}
 
 	public void setURL(String url1) {
 		values.put("url", url1);
+	}
+
+	public String getIPFS() {
+		return (String)values.get("ipfs");
+	}
+
+	public void setIPFS(String ipfs1) {
+		values.put("ipfs", ipfs1);
 	}
 
 	public String getArtist() {
@@ -95,15 +106,15 @@ public abstract class BMSTableElement {
 		}
 		return null;
 	}
-	
+
 	public void setParentHash(List<String> hashes) {
 		if(hashes == null || hashes.size() == 0) {
 			values.remove("org_md5");
 		} else {
 			values.put("org_md5", hashes);
-		}		
+		}
 	}
-	
+
 	public Map<String, Object> getValues() {
 		return values;
 	}
@@ -111,5 +122,5 @@ public abstract class BMSTableElement {
 	public void setValues(Map<String, Object> values) {
 		this.values.clear();
 		this.values.putAll(values);
-	}	
+	}
 }

--- a/src/bms/table/DifficultyTableElement.java
+++ b/src/bms/table/DifficultyTableElement.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 /**
  * 難易度表の要素
- * 
+ *
  * @author exch
  */
 public class DifficultyTableElement extends BMSTableElement implements
@@ -61,14 +61,14 @@ public class DifficultyTableElement extends BMSTableElement implements
 	 * 譜面情報
 	 */
 	private String info = "";
-	
+
 	private String proposer = "";
 
 	public DifficultyTableElement() {
 	}
 
 	public DifficultyTableElement(String did, String title, int bmsid,
-			String url1, String url2, String comment, String hash) {
+			String url1, String url2, String comment, String hash,String ipfs) {
 		this.setLevel(did);
 		this.setTitle(title);
 		this.setBMSID(bmsid);
@@ -76,8 +76,9 @@ public class DifficultyTableElement extends BMSTableElement implements
 		this.setAppendURL(url2);
 		this.setComment(comment);
 		this.setMD5(hash);
+		this.setIPFS(ipfs);
 	}
-	
+
 	public int getState() {
 		return state;
 	}
@@ -94,7 +95,7 @@ public class DifficultyTableElement extends BMSTableElement implements
 		if(did == null) {
 			level = "";
 		} else {
-			level = did;			
+			level = did;
 		}
 	}
 
@@ -130,6 +131,14 @@ public class DifficultyTableElement extends BMSTableElement implements
 		getValues().put("url_diff", url2);
 	}
 
+	public String getAppendIPFS() {
+		return (String)getValues().get("ipfs_diff");
+	}
+
+	public void setAppendIPFS(String ipfs2) {
+		getValues().put("ipfs_diff", ipfs2);
+	}
+
 	public String getAppendArtist() {
 		return diffname;
 	}
@@ -161,7 +170,7 @@ public class DifficultyTableElement extends BMSTableElement implements
 	public void setProposer(String proposer) {
 		this.proposer = proposer;
 	}
-	
+
 	public int getBMSID() {
 		int result = 0;
 		try {
@@ -195,7 +204,7 @@ public class DifficultyTableElement extends BMSTableElement implements
 
 		}
 		eval = evalvalue;
-		
+
 		Object level = values.get("level");
 		setLevel(level != null ? level.toString() : "");
 		Object diffname = values.get("name_diff");
@@ -218,7 +227,7 @@ public class DifficultyTableElement extends BMSTableElement implements
 		result.put("comment", getComment());
 		result.put("tag", getInformation());
 		if(getProposer() != null && getProposer().length() > 0) {
-			result.put("proposer", getProposer());			
+			result.put("proposer", getProposer());
 		} else {
 			result.remove("proposer");
 		}


### PR DESCRIPTION
IPFSとはP2Pなファイルシステムで、これに対応したBMS（ON）楽曲のIPFS pathをBMSTableに項目ipfs,ipfs_diffとして追加しようと思います。
### データ部、譜面情報オブジェクト内の任意項目
- ipfs: String BMS本体のipfsのpath
  - /ipfs/(ハッシュ値) という形式が期待されますが、ハッシュ値の部分だけでも可
  - ハッシュ値の示すIPFSオブジェクトは必ずディレクトリであり、ディレクトリの中身にmd5/sha256で指定されたBMSが含まれること
- ipfs_diff: String BMS差分のipfsのpath
  - ハッシュ値の示すIPFSオブジェクトはディレクトリ、ファイルどちらでも可だが、ファイルの場合拡張子が消えるためダウンロード後BMSかBMSONか判別する処理が必要

### どのようなことが可能となるか
- ブラウザで http://ipfs.io/ipfs/ (ノード値)にアクセスすることで、ファイルの閲覧、ダウンロードが行える
  - 例としては https://ipfs.io/ipfs/QmYrKcwqwr856fGQT6VCJL7Q2kxS5iY3yMzkefRjLfSNhv
- ipfs daemonを起動していれば、コマンドによりファイルのダウンロード、共有が行える
  - ダウンロード: ipfs get /ipfs/QmYrKcwqwr856fGQT6VCJL7Q2kxS5iY3yMzkefRjLfSNhv
  - 共有: ipfs pin add /ipfs/QmYrKcwqwr856fGQT6VCJL7Q2kxS5iY3yMzkefRjLfSNhv

### IPFSに関わる参考文献
- https://ipfs.io/
- https://postd.cc/an-introduction-to-ipfs/
- https://paper.dropbox.com/doc/Using-IPFS-for-BMSbmson-distribution-FCoGYTGzO9mlKY9EiSb8b

これがBMSの文化に使えるか？流行るのか？という辺りから色々話し合ったりしてみたいと思っております。
後にIPFSによるダウンロード機能をbeatorajaにPRを送る予定です。